### PR TITLE
Fix Client Credentials Grant

### DIFF
--- a/src/Heimdall.php
+++ b/src/Heimdall.php
@@ -49,6 +49,7 @@ abstract class Heimdall
     ): HeimdallAuthorizationServer
     {
         switch ($grant->getCode()) {
+            case HeimdallAuthorizationGrant::ClientCredentials:
             case HeimdallAuthorizationGrant::AuthorizationCode:
                 return new HeimdallAuthorizationServer($config, $grant, $oidc);
             default:

--- a/src/Server/HeimdallResourceServer.php
+++ b/src/Server/HeimdallResourceServer.php
@@ -66,7 +66,7 @@ class HeimdallResourceServer
     function validate(RequestInterface $request)
     {
         try {
-            $this->server->validateAuthenticatedRequest(
+            return $this->server->validateAuthenticatedRequest(
                 Heimdall::handleRequest(
                     new IncomingRequest(config('app'),
                         $request->uri, $request->getBody(),


### PR DESCRIPTION
When you create a Authorization Server using the withClientCredentialsGrant function builder.
See https://heimdall.ezralazuardy.com/documentation/client-credentials-grant
Error is:
<pre>
"title": "Heimdall\\Exception\\HeimdallConfigException",
"type": "Heimdall\\Exception\\HeimdallConfigException",
"code": 500,
"message": "Unknown Heimdall grant type, please recheck your parameter.",
"file": "vendor/ezralazuardy/heimdall/src/Heimdall.php",
"line": 56,
</pre>