### PR TITLE
Fix issues with CI 4.5 and PHP 8 compatibility

### DIFF
--- a/src/Heimdall.php
+++ b/src/Heimdall.php
@@ -12,7 +12,7 @@ use Heimdall\Exception\HeimdallServerException;
 use Heimdall\Extension\HeimdallOIDC;
 use Heimdall\Http\HeimdallRequest;
 use Heimdall\Http\HeimdallResponse;
-use Heimdall\interfaces\IdentityRepositoryInterface;
+use Heimdall\Interfaces\IdentityRepositoryInterface;
 use Heimdall\Server\HeimdallAuthorizationServer;
 use Heimdall\Server\HeimdallResourceServer;
 use League\OAuth2\Server\AuthorizationValidators\AuthorizationValidatorInterface;

--- a/src/Http/Collection.php
+++ b/src/Http/Collection.php
@@ -106,7 +106,7 @@ class Collection implements CollectionInterface
      * @return mixed The key's value, or the default value
      * @noinspection PhpParameterNameChangedDuringInheritanceInspection
      */
-    public function offsetGet($key)
+    public function offsetGet($key): mixed
     {
         return $this->get($key);
     }
@@ -126,7 +126,7 @@ class Collection implements CollectionInterface
      * @param mixed $value The data value
      * @noinspection PhpParameterNameChangedDuringInheritanceInspection
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->set($key, $value);
     }
@@ -137,7 +137,7 @@ class Collection implements CollectionInterface
      * @param string $key The data key
      * @noinspection PhpParameterNameChangedDuringInheritanceInspection
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         $this->remove($key);
     }

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -18,7 +18,7 @@ class Environment extends Collection implements EnvironmentInterface
     /**
      * {@inheritdoc}
      */
-    public static function mock(array $settings = [])
+    public static function mock(array $settings = []): EnvironmentInterface
     {
         //Validates if default protocol is HTTPS to set default port 443
         if ((isset($settings['HTTPS']) && $settings['HTTPS'] !== 'off') ||

--- a/src/Http/NonBufferedBody.php
+++ b/src/Http/NonBufferedBody.php
@@ -25,7 +25,7 @@ class NonBufferedBody implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function close()
+    public function close(): void
     {
     }
 
@@ -72,14 +72,14 @@ class NonBufferedBody implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function rewind()
+    public function rewind(): void
     {
     }
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -437,7 +437,7 @@ class Request extends Message implements ServerRequestInterface
      *
      * @return string
      */
-    public function getMethod(): ?string
+    public function getMethod(): string
     {
         if ($this->method === null) {
             $this->method = $this->originalMethod;
@@ -454,7 +454,7 @@ class Request extends Message implements ServerRequestInterface
                 }
             }
         }
-        return $this->method;
+        return $this->method ?? 'GET';
     }
 
     /**

--- a/src/Http/Stream.php
+++ b/src/Http/Stream.php
@@ -188,7 +188,7 @@ class Stream implements StreamInterface
      * @see seek()
      *
      */
-    public function rewind()
+    public function rewind(): void
     {
         if (!$this->isSeekable() || rewind($this->stream) === false) {
             throw new RuntimeException('Could not rewind stream');
@@ -295,7 +295,7 @@ class Stream implements StreamInterface
     /**
      * Closes the stream and any underlying resources.
      */
-    public function close()
+    public function close(): void
     {
         if ($this->isAttached() === true) {
             if ($this->isPipe()) {
@@ -361,7 +361,7 @@ class Stream implements StreamInterface
      *
      * @throws RuntimeException If stream is not seekable
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         // Note that fseek returns 0 on success!
         if (!$this->isSeekable() || fseek($this->stream, $offset, $whence) === -1) {

--- a/src/Http/UploadedFile.php
+++ b/src/Http/UploadedFile.php
@@ -174,7 +174,7 @@ class UploadedFile implements UploadedFileInterface
      *
      * @throws RuntimeException in cases when no stream is available or can be created.
      */
-    public function getStream()
+    public function getStream(): StreamInterface
     {
         if ($this->moved) {
             throw new RuntimeException(sprintf('Uploaded file %s has already been moved', $this->name));
@@ -219,7 +219,7 @@ class UploadedFile implements UploadedFileInterface
      * @throws InvalidArgumentException If the $path specified is invalid.
      * @throws RuntimeException On any error during the move operation or on the second subsequent call to the method.
      */
-    public function moveTo($targetPath)
+    public function moveTo($targetPath): void
     {
         if ($this->moved) {
             throw new RuntimeException('Uploaded file already moved');

--- a/src/Interfaces/Http/HeadersInterface.php
+++ b/src/Interfaces/Http/HeadersInterface.php
@@ -1,6 +1,6 @@
 <?php namespace Heimdall\Interfaces\Http;
 
-use Heimdall\interfaces\CollectionInterface;
+use Heimdall\Interfaces\CollectionInterface;
 
 /**
  * Part of Slim Framework (https://slimframework.com)

--- a/src/Server/HeimdallResourceServer.php
+++ b/src/Server/HeimdallResourceServer.php
@@ -69,7 +69,7 @@ class HeimdallResourceServer
             $response = $this->server->validateAuthenticatedRequest(
                 Heimdall::handleRequest(
                     new IncomingRequest(config('app'),
-                        $request->uri, $request->getBody(),
+                        $request->getUri(), $request->getBody(),
                         $request->getUserAgent()
                     )
                 )


### PR DESCRIPTION
* PHP 8 requires return types to match the parent method
* there was one place where $request->uri was still used (CI 4.5 made this protected, so we have to use getUri() instead)
* Heimdall/Interfaces/... didn't match case in use statements